### PR TITLE
Retry response timeout error

### DIFF
--- a/lib/services/large_result_set.js
+++ b/lib/services/large_result_set.js
@@ -26,7 +26,7 @@ function LargeResultSetService(connectionConfig, httpClient)
     // Note: 403's are retried because of a bug in S3/Blob
     return Util.isRetryableHttpError(
       response, true // retry HTTP 403
-    ) || err && (err.code === "ECONNRESET" || err.code === 'ETIMEDOUT');
+    ) || err && (err.code === "ECONNRESET" || err.code === 'ETIMEDOUT' || err.name === 'ResponseTimeoutError');
   }
 
   /**


### PR DESCRIPTION
We need to retry on response timeout error too, since those errors are usually retriable. 

https://app.datadoghq.com/logs?query=%22Could%20not%20reach%20S3%2FBlob%22%20service%3Aworker&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1669156345341&to_ts=1670452345341&live=true

